### PR TITLE
Updated documentation to clarify the use of keyFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ ip address of your tv
 - `mac` [required]
 Mac address of your tv
 - `keyFile` [optional]
-Path of the file to store permission token for your tv. If the file doesn't exist it'll be created. Don't specify a directory or you'll get an `EISDIR` error. 
+To prevent the tv from asking for permission when you reboot homebridge, specify a file path to store the permission token. If the file doesn't exist it'll be created. Don't specify a directory or you'll get an `EISDIR` error. 
 - `pollingEnabled` [optional]
 Wheter the TV state background polling is enabled. Useful for more accurate TV state awareness and HomeKit automation. **Default: false**
 - `pollingInterval` [optional]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Add the accessory in `config.json` in your home directory inside `.homebridge`.
       "name": "My webOS tv",
       "ip": "192.168.0.40",
       "mac": "ab:cd:ef:fe:dc:ba",
+      "keyFile": "/home/pi/.homebridge/lgtvKeyFile",
       "pollingEnabled": true,
       "externalInput": true,
       "externalSource": "HDMI_2"
@@ -62,7 +63,7 @@ ip address of your tv
 - `mac` [required]
 Mac address of your tv
 - `keyFile` [optional]
-Location to store permission token for your tv
+Path of the file to store permission token for your tv. If the file doesn't exist it'll be created. Don't specify a directory or you'll get an `EISDIR` error. 
 - `pollingEnabled` [optional]
 Wheter the TV state background polling is enabled. Useful for more accurate TV state awareness and HomeKit automation. **Default: false**
 - `pollingInterval` [optional]


### PR DESCRIPTION
I started to use `systemctl` to help manage homebridge. One of the features it is to restart homebridge if it crashes. I noticed that each time it restarts my TV would ask me permission about a remote app. Aftering finding #5 I realized that I could use the `keyFile` config to fix this, but it still wasn't working because I was specifying a directory path instead of a file path. This update makes this more clear so others won't make the same mistake I did.

Great work on this extension btw - it's a key part to my home automation efforts.