### PR TITLE
Add SHOW_INPUT_PICKER remote command

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ let Service, Characteristic, Homebridge, Accessory, HapStatusError, HAPStatus, H
 
 const PLUGIN_NAME = 'homebridge-webos-tv';
 const PLATFORM_NAME = 'webostv';
-const PLUGIN_VERSION = '2.4.6';
+const PLUGIN_VERSION = '2.4.7';
 
 // General constants
 const NOT_EXISTING_INPUT = 999999;

--- a/lib/LgTvController.js
+++ b/lib/LgTvController.js
@@ -27,6 +27,7 @@ const WEBOS_URI_OPEN_CHANNEL = 'ssap://tv/openChannel'; // params: output
 const WEBOS_URI_CHANNEL_UP = 'ssap://tv/channelUp'; // params: -
 const WEBOS_URI_CHANNEL_DOWN = 'ssap://tv/channelDown'; // params: -
 const WEBOS_URI_SWITCH_INPUT = 'ssap://tv/switchInput'; // params: inputId
+const WEBOS_URI_SHOW_INPUT_PICKER = 'ssap://com.webos.surfacemanager/showInputPicker'; // params: -
 const WEBOS_URI_TURN_OFF_SCREEN = 'ssap://com.webos.service.tv.power/turnOffScreen'; // params: standbyMode (active or passive[passive cannot turn screen back on])
 const WEBOS_URI_TURN_ON_SCREEN = 'ssap://com.webos.service.tv.power/turnOnScreen'; // params: standbyMode (active or passive[passive cannot turn screen back on])
 const WEBOS_URI_TURN_OFF_SCREEN_ALT = 'ssap://com.webos.service.tvpower/power/turnOffScreen'; // alternative version, probably for webOS5+ TVs, accepts the same params as above
@@ -63,7 +64,7 @@ const WEBOS_URI_SYSTEM_SETTINGS = 'ssap://settings/getSystemSettings';
 const WEBOS_URI_REMOTE_POINTER_SOCKET_INPUT = 'ssap://com.webos.service.networkinput/getPointerInputSocket';
 
 // TV remote command list
-const REMOTE_COMMANDS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "LIST", "AD", "DASH", "MUTE", "VOLUMEUP", "VOLUMEDOWN", "CHANNELUP", "CHANNELDOWN", "HOME", "MENU", "UP", "DOWN", "LEFT", "RIGHT", "CLICK", "BACK", "EXIT", "PROGRAM", "ENTER", "INFO", "RED", "GREEN", "YELLOW", "BLUE", "LIVE_ZOOM", "CC", "PLAY", "PAUSE", "REWIND", "FASTFORWARD", "POWER", "FAVORITES", "RECORD", "FLASHBACK", "QMENU", "GOTOPREV", "GOTONEXT", "3D_MODE", "SAP", "ASPECT_RATIO", "EJECT", "MYAPPS", "RECENT", "BS", "BS_NUM_1", "BS_NUM_2", "BS_NUM_3", "BS_NUM_4", "BS_NUM_5", "BS_NUM_6", "BS_NUM_7", "BS_NUM_8", "BS_NUM_9", "BS_NUM_10", "BS_NUM_11", "BS_NUM_12", "CS1", "CS1_NUM_1", "CS1_NUM_2", "CS1_NUM_3", "CS1_NUM_4", "CS1_NUM_5", "CS1_NUM_6", "CS1_NUM_7", "CS1_NUM_8", "CS1_NUM_9", "CS1_NUM_10", "CS1_NUM_11", "CS1_NUM_12", "CS2", "CS2_NUM_1", "CS2_NUM_2", "CS2_NUM_3", "CS2_NUM_4", "CS2_NUM_5", "CS2_NUM_6", "CS2_NUM_7", "CS2_NUM_8", "CS2_NUM_9", "CS2_NUM_10", "CS2_NUM_11", "CS2_NUM_12", "TER", "TER_NUM_1", "TER_NUM_2", "TER_NUM_3", "TER_NUM_4", "TER_NUM_5", "TER_NUM_6", "TER_NUM_7", "TER_NUM_8", "TER_NUM_9", "TER_NUM_10", "TER_NUM_11", "TER_NUM_12", "3DIGIT_INPUT", "BML_DATA", "JAPAN_DISPLAY", "TELETEXT", "TEXTOPTION", "MAGNIFIER_ZOOM", "SCREEN_REMOT"];
+const REMOTE_COMMANDS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "LIST", "AD", "DASH", "MUTE", "VOLUMEUP", "VOLUMEDOWN", "CHANNELUP", "CHANNELDOWN", "HOME", "MENU", "UP", "DOWN", "LEFT", "RIGHT", "CLICK", "BACK", "EXIT", "PROGRAM", "ENTER", "INFO", "RED", "GREEN", "YELLOW", "BLUE", "LIVE_ZOOM", "CC", "PLAY", "PAUSE", "REWIND", "FASTFORWARD", "POWER", "FAVORITES", "RECORD", "FLASHBACK", "QMENU", "GOTOPREV", "GOTONEXT", "3D_MODE", "SAP", "ASPECT_RATIO", "EJECT", "MYAPPS", "RECENT", "BS", "BS_NUM_1", "BS_NUM_2", "BS_NUM_3", "BS_NUM_4", "BS_NUM_5", "BS_NUM_6", "BS_NUM_7", "BS_NUM_8", "BS_NUM_9", "BS_NUM_10", "BS_NUM_11", "BS_NUM_12", "CS1", "CS1_NUM_1", "CS1_NUM_2", "CS1_NUM_3", "CS1_NUM_4", "CS1_NUM_5", "CS1_NUM_6", "CS1_NUM_7", "CS1_NUM_8", "CS1_NUM_9", "CS1_NUM_10", "CS1_NUM_11", "CS1_NUM_12", "CS2", "CS2_NUM_1", "CS2_NUM_2", "CS2_NUM_3", "CS2_NUM_4", "CS2_NUM_5", "CS2_NUM_6", "CS2_NUM_7", "CS2_NUM_8", "CS2_NUM_9", "CS2_NUM_10", "CS2_NUM_11", "CS2_NUM_12", "TER", "TER_NUM_1", "TER_NUM_2", "TER_NUM_3", "TER_NUM_4", "TER_NUM_5", "TER_NUM_6", "TER_NUM_7", "TER_NUM_8", "TER_NUM_9", "TER_NUM_10", "TER_NUM_11", "TER_NUM_12", "3DIGIT_INPUT", "BML_DATA", "JAPAN_DISPLAY", "TELETEXT", "TEXTOPTION", "MAGNIFIER_ZOOM", "SCREEN_REMOT", "SHOW_INPUT_PICKER"];
 
 //nice to haves:
 //TODO: Subscription for tv screen turn on or off? // did not find anything yet
@@ -1382,9 +1383,13 @@ class LgTvController extends EventEmitter {
           if (cmd === 'CLICK') {
             this.pointerInputSocket.send('click');
           } else {
-            this.pointerInputSocket.send('button', {
-              name: cmd
-            });
+            if (cmd === 'SHOW_INPUT_PICKER') {
+              this.showInputPicker();
+            } else {
+              this.pointerInputSocket.send('button', {
+                name: cmd
+              });
+            }
           }
         } else {
           this.logDebug(`Remote input socket - command does not exist!`);
@@ -1395,6 +1400,10 @@ class LgTvController extends EventEmitter {
     } else {
       this.logDebug(`Remote input socket - tv not connected or remote input socket not established!`);
     }
+  }
+
+  showInputPicker() {
+    this.tvRequest(WEBOS_URI_SHOW_INPUT_PICKER);
   }
 
   sendPlayPause() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-webos-tv",
   "displayName": "webOS TV",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "description": "Homebridge plugin for LG webOS TVs",
   "type": "module",
   "exports": "./index.js",


### PR DESCRIPTION
I noticed that there wasn't a remote command for showing the input picker.

I use an AVR, so all inputs are only tied to one HDMI port and show up as (virtual) CEC player inputs in the input picker (basically the same as https://github.com/merdok/homebridge-webos-tv/issues/515). But selecting the input on the AVR doesn't help in cases where I need to interact with the TV via the Control Center remote after switching the input. This is because the TV doesn't register that the AVR switched sources and keeps sending subsequent CEC remote commands to the device that is no longer shown on the screen.
That's why I wanted to have the option to show the input picker from the Control Center remote.

After some searching I came across [this guide](https://github.com/home-assistant/home-assistant.io/issues/32735) which mentions that `com.webos.surfacemanager/showInputPicker` can be used to show the input picker.

With my proposed changes, `SHOW_INPUT_PICKER` can now be set e.g. in `ccRemoteRemap` to make the input picker appear on screen.

I've implemented this in a somewhat minimally invasive way as a part of `sendRemoteInputSocketCommand`. This doesn't really fit the function's name anymore, since it's not using the remote input socket. It also means that the debug log output doesn't really match anymore. But I'm not sure if this could be implemented in a cleaner way without also making other major changes to how remote commands are handled.